### PR TITLE
ci: reënable golangci-lint

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,19 +14,18 @@ jobs:
       - uses: actions/checkout@v6
       - run: go test ./...
 
-      # I'm going to reënable this in a follow-up PR
-      # - name: golangci-lint
-      #   # https://github.com/golangci/golangci-lint-action has some options you can set
-      #   # they recomnmend running it in a separate action, do so if it feels necessary
-      #   uses: golangci/golangci-lint-action@v9.2.1
-      #   with:
-      #     version: latest
-      #     # Optional: show only new issues if it's a pull request. The default value is `false`.
-      #     # only-new-issues: true
-      #     # Optional: if set to true then the all caching functionality will be complete disabled,
-      #     #           takes precedence over all other caching options.
-      #     # skip-cache: true
-      #     # Optional: if set to true then the action don't cache or restore ~/go/pkg.
-      #     # skip-pkg-cache: true
-      #     # Optional: if set to true then the action don't cache or restore ~/.cache/go-build.
-      #     # skip-build-cache: true
+      - name: golangci-lint
+        # https://github.com/golangci/golangci-lint-action has some options you can set
+        # they recomnmend running it in a separate action, do so if it feels necessary
+        uses: golangci/golangci-lint-action@v9.2.1
+        with:
+          version: latest
+          # Optional: show only new issues if it's a pull request. The default value is `false`.
+          # only-new-issues: true
+          # Optional: if set to true then the all caching functionality will be complete disabled,
+          #           takes precedence over all other caching options.
+          # skip-cache: true
+          # Optional: if set to true then the action don't cache or restore ~/go/pkg.
+          # skip-pkg-cache: true
+          # Optional: if set to true then the action don't cache or restore ~/.cache/go-build.
+          # skip-build-cache: true

--- a/fileserver/fileserver.go
+++ b/fileserver/fileserver.go
@@ -19,7 +19,7 @@ import (
 	"strings"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"github.com/cortesi/termlog"
 	"github.com/llimllib/devd/inject"

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/juju/ratelimit v1.0.2
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/toqueteos/webbrowser v1.2.1
-	golang.org/x/net v0.56.0
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 )
 
@@ -24,6 +23,7 @@ require (
 	github.com/mattn/go-colorable v0.1.15 // indirect
 	github.com/mattn/go-isatty v0.0.22 // indirect
 	github.com/rjeczalik/notify v0.9.3 // indirect
+	golang.org/x/net v0.56.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect
 	golang.org/x/term v0.44.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect

--- a/httpctx/httpctx.go
+++ b/httpctx/httpctx.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"strings"
 
-	"golang.org/x/net/context"
+	"context"
 )
 
 // Handler is a request handler with an added context

--- a/livereload/livereload.go
+++ b/livereload/livereload.go
@@ -81,7 +81,7 @@ func (s *Server) run(broadcast <-chan string) {
 	defer s.Unlock()
 	for conn := range s.connections {
 		delete(s.connections, conn)
-		conn.Close()
+		_ = conn.Close()
 	}
 }
 

--- a/reverseproxy/reverseproxy.go
+++ b/reverseproxy/reverseproxy.go
@@ -14,7 +14,7 @@ import (
 	"sync"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"github.com/llimllib/devd/inject"
 	"github.com/cortesi/termlog"
@@ -168,7 +168,7 @@ func (p *ReverseProxy) ServeHTTPContext(
 		rw.WriteHeader(http.StatusInternalServerError)
 		return
 	}
-	defer res.Body.Close()
+	defer res.Body.Close() //nolint:errcheck
 	if req.ContentLength > 0 {
 		log.Say(fmt.Sprintf("%s uploaded", humanize.Bytes(uint64(req.ContentLength))))
 	}

--- a/reverseproxy/reverseproxy_test.go
+++ b/reverseproxy/reverseproxy_test.go
@@ -164,7 +164,7 @@ func TestReverseProxyQuery(t *testing.T) {
 		if g, e := res.Header.Get("X-Got-Query"), tt.want; g != e {
 			t.Errorf("%d. got query %q; expected %q", i, g, e)
 		}
-		res.Body.Close()
+		_ = res.Body.Close()
 		frontend.Close()
 	}
 }
@@ -199,7 +199,7 @@ func TestReverseProxyFlushInterval(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Get: %v", err)
 	}
-	defer res.Body.Close()
+	defer res.Body.Close() //nolint:errcheck
 	if bodyBytes, _ := io.ReadAll(res.Body); string(bodyBytes) != expected {
 		t.Errorf("got body %q; expected %q", bodyBytes, expected)
 	}

--- a/server.go
+++ b/server.go
@@ -13,7 +13,7 @@ import (
 	"syscall"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"github.com/goji/httpauth"
 

--- a/timer/timer.go
+++ b/timer/timer.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 )
 
 // Timer collects request and response timing information
@@ -47,14 +47,20 @@ func (t *Timer) ResponseDone() {
 	t.tsResponseDone = time.Now().UnixNano()
 }
 
+// contextKey is an unexported type for context keys in this package.
+type contextKey struct{}
+
+// timerKey is the context key for the Timer.
+var timerKey = contextKey{}
+
 // NewContext creates a new context with the timer included
 func (t *Timer) NewContext(ctx context.Context) context.Context {
-	return context.WithValue(ctx, "timer", t)
+	return context.WithValue(ctx, timerKey, t)
 }
 
-// FromContext creates a new context with the timer included
+// FromContext retrieves a Timer from the context
 func FromContext(ctx context.Context) *Timer {
-	timer, ok := ctx.Value("timer").(*Timer)
+	timer, ok := ctx.Value(timerKey).(*Timer)
 	if !ok {
 		// Return a dummy timer
 		return &Timer{}

--- a/watch_test.go
+++ b/watch_test.go
@@ -25,7 +25,7 @@ func TestRouteWatch(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	defer os.RemoveAll(tmpFolder)
+	defer os.RemoveAll(tmpFolder) //nolint:errcheck
 
 	// Ensure that using . for the path works:
 	if err := os.Chdir(tmpFolder); err != nil {


### PR DESCRIPTION
I disabled it because we needed to modernize a bit to enable it, this PR does that work.
