### PR TITLE
args: fix short arg handling with pflag

### DIFF
--- a/cmd/devd/devd.go
+++ b/cmd/devd/devd.go
@@ -1,26 +1,17 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 	"net/http"
 	"os"
 	"path"
-	"strings"
+
+	flag "github.com/spf13/pflag"
 
 	"github.com/cortesi/termlog"
 	"github.com/llimllib/devd"
 	"github.com/toqueteos/webbrowser"
 )
-
-// stringSlice implements flag.Value for flags that can be specified multiple times
-type stringSlice []string
-
-func (s *stringSlice) String() string { return strings.Join(*s, ", ") }
-func (s *stringSlice) Set(val string) error {
-	*s = append(*s, val)
-	return nil
-}
 
 func fatalf(format string, args ...any) {
 	fmt.Fprintf(os.Stderr, "devd: error: "+format+"\n", args...)
@@ -50,85 +41,37 @@ func main() {
 		corsFlag     bool
 		debug        bool
 		version      bool
-		notfound     stringSlice
-		ignoreLogs   stringSlice
-		watch        stringSlice
-		excludes     stringSlice
+		notfound     []string
+		ignoreLogs   []string
+		watch        []string
+		excludes     []string
 	)
 
-	flag.StringVar(&address, "address", "127.0.0.1", "Address to listen on")
-	flag.StringVar(&address, "A", "127.0.0.1", "Address to listen on (shorthand)")
-
-	flag.BoolVar(&allIfaces, "all", false, "Listen on all addresses")
-	flag.BoolVar(&allIfaces, "a", false, "Listen on all addresses (shorthand)")
-
-	flag.StringVar(&certFile, "cert", "", "Certificate bundle file - enables TLS")
-	flag.StringVar(&certFile, "c", "", "Certificate bundle file - enables TLS (shorthand)")
-
-	flag.BoolVar(&forceColor, "color", false, "Enable colour output, even if devd is not connected to a terminal")
-	flag.BoolVar(&forceColor, "C", false, "Enable colour output (shorthand)")
-
-	flag.UintVar(&downKbps, "down", 0, "Throttle downstream from the client to N kilobytes per second")
-	flag.UintVar(&downKbps, "d", 0, "Throttle downstream (shorthand)")
-
-	flag.Var(&notfound, "notfound", "Default when a static file is not found (can be repeated)")
-	flag.Var(&notfound, "f", "Default when a static file is not found (shorthand, can be repeated)")
-
-	flag.BoolVar(&logHeaders, "logheaders", false, "Log headers")
-	flag.BoolVar(&logHeaders, "H", false, "Log headers (shorthand)")
-
-	flag.Var(&ignoreLogs, "ignore", "Disable logging matching requests. Regexes are matched over 'host/path' (can be repeated)")
-	flag.Var(&ignoreLogs, "I", "Disable logging matching requests (shorthand, can be repeated)")
-
-	flag.BoolVar(&lrNaked, "livereload", false, "Enable livereload")
-	flag.BoolVar(&lrNaked, "L", false, "Enable livereload (shorthand)")
-
-	flag.BoolVar(&lrRoutes, "livewatch", false, "Enable livereload and watch for static file changes")
-	flag.BoolVar(&lrRoutes, "l", false, "Enable livereload and watch (shorthand)")
-
-	flag.BoolVar(&moddMode, "modd", false, "Modd is our parent - synonym for -LCt")
-	flag.BoolVar(&moddMode, "m", false, "Modd is our parent (shorthand)")
-
-	flag.IntVar(&latency, "latency", 0, "Add N milliseconds of round-trip latency")
-	flag.IntVar(&latency, "n", 0, "Add N milliseconds of round-trip latency (shorthand)")
-
-	flag.BoolVar(&openBrowser, "open", false, "Open browser window on startup")
-	flag.BoolVar(&openBrowser, "o", false, "Open browser window on startup (shorthand)")
-
-	flag.IntVar(&port, "port", 0, "Port to listen on - if not specified, devd will auto-pick a sensible port")
-	flag.IntVar(&port, "p", 0, "Port to listen on (shorthand)")
-
-	flag.StringVar(&credspec, "password", "", "HTTP basic password protection (USER:PASS)")
-	flag.StringVar(&credspec, "P", "", "HTTP basic password protection (shorthand)")
-
-	flag.BoolVar(&quiet, "quiet", false, "Silence all logs")
-	flag.BoolVar(&quiet, "q", false, "Silence all logs (shorthand)")
-
-	flag.BoolVar(&tlsFlag, "tls", false, "Serve TLS with auto-generated self-signed certificate (~/.devd.cert)")
-	flag.BoolVar(&tlsFlag, "s", false, "Serve TLS (shorthand)")
-
-	flag.BoolVar(&noTimestamps, "notimestamps", false, "Disable timestamps in output")
-	flag.BoolVar(&noTimestamps, "t", false, "Disable timestamps in output (shorthand)")
-
-	flag.BoolVar(&logTime, "logtime", false, "Log timing")
-	flag.BoolVar(&logTime, "T", false, "Log timing (shorthand)")
-
-	flag.UintVar(&upKbps, "up", 0, "Throttle upstream from the client to N kilobytes per second")
-	flag.UintVar(&upKbps, "u", 0, "Throttle upstream (shorthand)")
-
-	flag.Var(&watch, "watch", "Watch path to trigger livereload (can be repeated)")
-	flag.Var(&watch, "w", "Watch path to trigger livereload (shorthand, can be repeated)")
-
-	flag.BoolVar(&corsFlag, "crossdomain", false, "Set the CORS headers to allow everything (origin, credentials, headers, methods)")
-	flag.BoolVar(&corsFlag, "X", false, "Set the CORS headers (shorthand)")
-
-	flag.Var(&excludes, "exclude", "Glob pattern for files to exclude from livereload (can be repeated)")
-	flag.Var(&excludes, "x", "Glob pattern for files to exclude (shorthand, can be repeated)")
-
+	flag.StringVarP(&address, "address", "A", "127.0.0.1", "Address to listen on")
+	flag.BoolVarP(&allIfaces, "all", "a", false, "Listen on all addresses")
+	flag.StringVarP(&certFile, "cert", "c", "", "Certificate bundle file - enables TLS")
+	flag.BoolVarP(&forceColor, "color", "C", false, "Enable colour output, even if devd is not connected to a terminal")
+	flag.UintVarP(&downKbps, "down", "d", 0, "Throttle downstream from the client to N kilobytes per second")
+	flag.StringArrayVarP(&notfound, "notfound", "f", nil, "Default when a static file is not found")
+	flag.BoolVarP(&logHeaders, "logheaders", "H", false, "Log headers")
+	flag.StringArrayVarP(&ignoreLogs, "ignore", "I", nil, "Disable logging matching requests. Regexes are matched over 'host/path'")
+	flag.BoolVarP(&lrNaked, "livereload", "L", false, "Enable livereload")
+	flag.BoolVarP(&lrRoutes, "livewatch", "l", false, "Enable livereload and watch for static file changes")
+	flag.BoolVarP(&moddMode, "modd", "m", false, "Modd is our parent - synonym for -LCt")
+	flag.IntVarP(&latency, "latency", "n", 0, "Add N milliseconds of round-trip latency")
+	flag.BoolVarP(&openBrowser, "open", "o", false, "Open browser window on startup")
+	flag.IntVarP(&port, "port", "p", 0, "Port to listen on - if not specified, devd will auto-pick a sensible port")
+	flag.StringVarP(&credspec, "password", "P", "", "HTTP basic password protection (USER:PASS)")
+	flag.BoolVarP(&quiet, "quiet", "q", false, "Silence all logs")
+	flag.BoolVarP(&tlsFlag, "tls", "s", false, "Serve TLS with auto-generated self-signed certificate (~/.devd.cert)")
+	flag.BoolVarP(&noTimestamps, "notimestamps", "t", false, "Disable timestamps in output")
+	flag.BoolVarP(&logTime, "logtime", "T", false, "Log timing")
+	flag.UintVarP(&upKbps, "up", "u", 0, "Throttle upstream from the client to N kilobytes per second")
+	flag.StringArrayVarP(&watch, "watch", "w", nil, "Watch path to trigger livereload")
+	flag.BoolVarP(&corsFlag, "crossdomain", "X", false, "Set the CORS headers to allow everything (origin, credentials, headers, methods)")
+	flag.StringArrayVarP(&excludes, "exclude", "x", nil, "Glob pattern for files to exclude from livereload")
 	flag.BoolVar(&debug, "debug", false, "Debugging for devd development")
-
-	flag.BoolVar(&version, "version", false, "Print version and exit")
-	flag.BoolVar(&version, "v", false, "Print version and exit (shorthand)")
+	flag.BoolVarP(&version, "version", "v", false, "Print version and exit")
 
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Usage: devd [flags] route [route ...]\n\n")

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/mattn/go-colorable v0.1.15 // indirect
 	github.com/mattn/go-isatty v0.0.22 // indirect
 	github.com/rjeczalik/notify v0.9.3 // indirect
+	github.com/spf13/pflag v1.0.10 // indirect
 	golang.org/x/net v0.56.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect
 	golang.org/x/term v0.44.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -21,6 +21,8 @@ github.com/mattn/go-isatty v0.0.22 h1:j8l17JJ9i6VGPUFUYoTUKPSgKe/83EYU2zBC7YNKMw
 github.com/mattn/go-isatty v0.0.22/go.mod h1:ZXfXG4SQHsB/w3ZeOYbR0PrPwLy+n6xiMrJlRFqopa4=
 github.com/rjeczalik/notify v0.9.3 h1:6rJAzHTGKXGj76sbRgDiDcYj/HniypXmSJo1SWakZeY=
 github.com/rjeczalik/notify v0.9.3/go.mod h1:gF3zSOrafR9DQEWSE8TjfI9NkooDxbyT4UgRGKZA0lc=
+github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=
+github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/toqueteos/webbrowser v1.2.1 h1:O7IsnnU7XQyJ1nHMRfAktUUJOAZD3aQyUVnxzhWphCg=
 github.com/toqueteos/webbrowser v1.2.1/go.mod h1:XWoZq4cyp9WeUeak7w7LXRUQf1F1ATJMir8RTqb4ayM=
 golang.org/x/net v0.56.0 h1:Rw8j/hFzGvJUZwNBXnAtf5sVDVt+65SK2C7IxCxZt5o=


### PR DESCRIPTION
- parse args with pflag to get unix-style arg handling
- get old-style help formatting back
